### PR TITLE
#2376 の修正

### DIFF
--- a/lib/action/opCommunityTopicPluginEventCommentActions.class.php
+++ b/lib/action/opCommunityTopicPluginEventCommentActions.class.php
@@ -64,7 +64,7 @@ abstract class opCommunityTopicPluginEventCommentActions extends sfActions
       }
       catch (opCommunityEventMemberAppendableException $e)
       {
-        $this->getUser()->setFlash('error', $e->getMessage());
+        $this->getUser()->setFlash('error', $e->getMessage(), false);
       }
     }
 


### PR DESCRIPTION
#2376: イベント参加画面にてエラーのアラートが表示され続ける

（ http://redmine.openpne.jp/issues/2376 ）の修正です
