### PR TITLE
pc_backendのトピックリスト・イベントリスト・トピックコメントリスト・イベントコメントリストの並び順を新しい順にする(fix #1679)

### DIFF
--- a/apps/pc_backend/modules/communityTopic/actions/actions.class.php
+++ b/apps/pc_backend/modules/communityTopic/actions/actions.class.php
@@ -42,6 +42,7 @@ class communityTopicActions extends sfActions
     {
       $this->pager->setQuery($this->form->getQuery());
     }
+    $this->pager->setQuery($this->pager->getQuery()->orderBy('created_at DESC'));
     $this->pager->setPage($request->getParameter('page', 1));
     $this->pager->init();
     return sfView::SUCCESS;
@@ -82,6 +83,7 @@ class communityTopicActions extends sfActions
     {
       $this->pager->setQuery($this->form->getQuery());
     }
+    $this->pager->setQuery($this->pager->getQuery()->orderBy('created_at DESC'));
     $this->pager->setPage($request->getParameter('page', 1));
     $this->pager->init();
     return sfView::SUCCESS;
@@ -122,6 +124,7 @@ class communityTopicActions extends sfActions
     {
       $this->pager->setQuery($this->form->getQuery());
     }
+    $this->pager->setQuery($this->pager->getQuery()->orderBy('created_at DESC'));
     $this->pager->setPage($request->getParameter('page', 1));
     $this->pager->init();
     return sfView::SUCCESS;
@@ -202,6 +205,7 @@ class communityTopicActions extends sfActions
     {
       $this->pager->setQuery($this->form->getQuery());
     }
+    $this->pager->setQuery($this->pager->getQuery()->orderBy('created_at DESC'));
     $this->pager->setPage($request->getParameter('page', 1));
     $this->pager->init();
     return sfView::SUCCESS;

--- a/test/functional/pc_backend/communityTopicEventCommentListOrderingTest.php
+++ b/test/functional/pc_backend/communityTopicEventCommentListOrderingTest.php
@@ -1,0 +1,55 @@
+<?php
+
+include(dirname(__FILE__).'/../../bootstrap/functional.php');
+include(dirname(__FILE__).'/../../bootstrap/database.php');
+
+$_app = 'pc_backend';
+$browser = new opTestFunctional(new opBrowser(), new lime_test(null, new lime_output_color()));
+$browser
+  ->info('Login')
+  ->get('/default/login')
+  ->click('ログイン', array('admin_user' => array(
+    'username' => 'admin',
+    'password' => 'password',
+  )))
+  ->with('user')->isAuthenticated();
+
+$browser->get('/communityTopic/topicList')
+  ->with('request')->begin()
+    ->isParameter('module', 'communityTopic')
+    ->isParameter('action', 'topicList')
+  ->end()
+  ->with('response')->begin()
+    ->isStatusCode(200)
+  ->end()
+;
+
+$browser->get('/communityTopic/eventList')
+  ->with('request')->begin()
+    ->isParameter('module', 'communityTopic')
+    ->isParameter('action', 'eventList')
+  ->end()
+  ->with('response')->begin()
+    ->isStatusCode(200)
+  ->end()
+;
+
+$browser->get('/communityTopic/topicCommentList')
+  ->with('request')->begin()
+    ->isParameter('module', 'communityTopic')
+    ->isParameter('action', 'topicCommentList')
+  ->end()
+  ->with('response')->begin()
+    ->isStatusCode(200)
+  ->end()
+;
+
+$browser->get('/communityTopic/eventCommentList')
+  ->with('request')->begin()
+    ->isParameter('module', 'communityTopic')
+    ->isParameter('action', 'eventCommentList')
+  ->end()
+  ->with('response')->begin()
+    ->isStatusCode(200)
+  ->end()
+;


### PR DESCRIPTION
redmineのチケット「管理画面のトピックリストの並び順が降順でない」 http://redmine.openpne.jp/issues/1679 の対応分です。

参考：[OpenPNEバグ？？報告所] トピック "３系管理画面トピックコメントリストが古い投稿順に表示されています。" http://sns.openpne.jp/communityTopic/7845

機能テストですが、付属のfixtureでは動かないためこちらでデータを改変して実行してグリーン確認したものです。（AdminUserを追加、999_test_data.ymlと999_xss_test_data.ymlでprimary keyがぶつかっている為、一旦xss.ymlのほうを削除して実行）

よろしくお願いします。
