### PR TITLE
#2815 の修正

### DIFF
--- a/apps/mobile_frontend/i18n/messages.ja.xml
+++ b/apps/mobile_frontend/i18n/messages.ja.xml
@@ -250,6 +250,10 @@
         <source>Post from E-mail</source>
         <target>ﾒｰﾙ投稿</target>
       </trans-unit>
+      <trans-unit id="">
+        <source>More</source>
+        <target>もっと見る</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/apps/pc_frontend/i18n/messages.ja.xml
+++ b/apps/pc_frontend/i18n/messages.ja.xml
@@ -246,6 +246,10 @@
         <source>Photo 3</source>
         <target>写真3</target>
       </trans-unit>
+      <trans-unit id="">
+        <source>More</source>
+        <target>もっと見る</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
コミュニティホーム画面でコミュニティトピックおよびコミュニティイベントの「もっと見る」のリンクが翻訳されない
http://redmine.openpne.jp/issues/2815

修正しました。
よろしくお願いします。
