### PR TITLE
#2816 の修正

### DIFF
--- a/apps/mobile_frontend/i18n/messages.ja.xml
+++ b/apps/mobile_frontend/i18n/messages.ja.xml
@@ -210,6 +210,10 @@
         <source>The application deadline must be before the open date.</source>
         <target>募集期限は開催日時より後に指定できません。</target>
       </trans-unit>
+      <trans-unit id="">
+        <source>More</source>
+        <target>もっと見る</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/apps/pc_frontend/i18n/messages.ja.xml
+++ b/apps/pc_frontend/i18n/messages.ja.xml
@@ -162,6 +162,10 @@
         <source>Comment</source>
         <target>コメント</target>
       </trans-unit>
+      <trans-unit id="">
+        <source>More</source>
+        <target>もっと見る</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
コミュニティホーム画面でコミュニティトピックおよびコミュニティイベントの「もっと見る」のリンクが翻訳されない
http://redmine.openpne.jp/issues/2816

修正しました。
よろしくお願いします。
