### PR TITLE
トピック検索画面に非公開コミュニティのトピックが表示されない問題の修正 (#3158)

### DIFF
--- a/lib/action/opCommunityTopicPluginTopicActions.class.php
+++ b/lib/action/opCommunityTopicPluginTopicActions.class.php
@@ -229,7 +229,7 @@ abstract class opCommunityTopicPluginTopicActions extends sfActions
       $this->pageUrl .= '?id='.$this->communityId;
     }
 
-    $q = $table->getSearchQuery($request->getParameter('id'), $request->getParameter('target'), $request->getParameter('keyword'));
+    $q = $table->getSearchQuery($request->getParameter('id'), $request->getParameter('target'), $request->getParameter('keyword'), $this->getUser()->getMemberId());
     $this->pager = $table->getResultListPager($q, $request->getParameter('page'));
 
     $this->isResult = false;

--- a/lib/model/doctrine/PluginCommunityTopicTable.class.php
+++ b/lib/model/doctrine/PluginCommunityTopicTable.class.php
@@ -82,7 +82,7 @@ class PluginCommunityTopicTable extends Doctrine_Table
     return $pager;
   }
 
-  public function getSearchQuery($communityId = null, $target = null, $keyword = null)
+  public function getSearchQuery($communityId = null, $target = null, $keyword = null, $memberId = null)
   {
     $q = $this->createQuery();
 
@@ -105,7 +105,14 @@ class PluginCommunityTopicTable extends Doctrine_Table
       }
     }
 
-    $q->andWhereIn('community_id', opCommunityTopicToolkit::getPublicCommunityIdList())
+    $targetCommunityIds = opCommunityTopicToolkit::getPublicCommunityIdList();
+    if (!is_null($memberId))
+    {
+      $targetCommunityIds = array_merge($targetCommunityIds,
+        Doctrine_Core::getTable('Community')->getIdsByMemberId($memberId));
+    }
+
+    $q->andWhereIn('community_id', $targetCommunityIds)
       ->orderBy('updated_at DESC');
 
     return $q;


### PR DESCRIPTION
Bug #3158: コミュニティ内トピック検索で「トピックを参加者のみに公開」の場合、コミュニティ参加者にトピックが表示されない
https://redmine.openpne.jp/issues/3158

に対する修正です。
