### PR TITLE
タイムライン自動投稿時に「%community%」が変換されない件の修正

### DIFF
--- a/lib/model/doctrine/PluginCommunityEvent.class.php
+++ b/lib/model/doctrine/PluginCommunityEvent.class.php
@@ -123,7 +123,8 @@ abstract class PluginCommunityEvent extends BaseCommunityEvent
       sfContext::getInstance()->getConfiguration()->loadHelpers(array('Helper', 'opUtil'));
 
       $open = op_format_date($this->getOpenDate(), 'D').($this->getOpenDate() ? ' '.$this->getOpenDateComment() : '');
-      $body = '[%Community% Event] ('.$this->getCommunity()->getName().' %community%) '.$this->name.' (open '.$open.')';
+      $community = sfContext::getInstance()->getI18N()->__('%community%');
+      $body = '['.$community.' Event] ('.$this->getCommunity()->getName().' '.$community.') '.$this->name.' (open '.$open.')';
       $options = array(
         'public_flag' => $this->getCommunity()->getConfig('public_flag') === 'public' ? 1 : 3,
         'uri' => '@communityEvent_show?id='.$this->id,

--- a/lib/model/doctrine/PluginCommunityTopic.class.php
+++ b/lib/model/doctrine/PluginCommunityTopic.class.php
@@ -70,7 +70,8 @@ abstract class PluginCommunityTopic extends BaseCommunityTopic
     if (Doctrine::getTable('SnsConfig')->get('op_community_topic_plugin_update_activity', false)
       && defined('OPENPNE_VERSION') && version_compare(OPENPNE_VERSION, '3.6beta1-dev', '>='))
     {
-      $body = '[%Community% Topic] ('.$this->getCommunity()->getName().' %community%) '.$this->name;
+      $community = sfContext::getInstance()->getI18N()->__('%community%');
+      $body = '['.$community.' Topic] ('.$this->getCommunity()->getName().' '. $community .') '.$this->name;
       $options = array(
         'public_flag' => $this->getCommunity()->getConfig('public_flag') === 'public' ? 1 : 3,
         'uri' => '@communityTopic_show?id='.$this->id,


### PR DESCRIPTION
タイムライン更新設定を「使用するに設定されている場合」、トピック投稿時・イベント投稿時等にタイムラインに「%community%」と表示されてしまう件の修正です。

この件の修正前の投稿はすでにDBに保存されているため修正されません。
