### PR TITLE
#2591: 画像が添付されたコミュニティトピックを削除しても、管理画面のアップロード画像リストに画像が残る

### DIFF
--- a/lib/model/doctrine/PluginCommunityEvent.class.php
+++ b/lib/model/doctrine/PluginCommunityEvent.class.php
@@ -53,6 +53,19 @@ abstract class PluginCommunityEvent extends BaseCommunityEvent
     }
   }
 
+  public function preDelete($event)
+  {
+    foreach ($this->Images as $eventImage)
+    {
+      $eventImage->delete();
+    }
+
+    foreach ($this->CommunityEventComment as $eventComment)
+    {
+      $eventComment->delete();
+    }
+  }
+
   public function toggleEventMember($memberId)
   {
     if ($this->isClosed())

--- a/lib/model/doctrine/PluginCommunityEventComment.class.php
+++ b/lib/model/doctrine/PluginCommunityEventComment.class.php
@@ -32,6 +32,14 @@ abstract class PluginCommunityEventComment extends BaseCommunityEventComment
     }
   }
 
+  public function preDelete($event)
+  {
+    foreach ($this->Images as $eventCommentImage)
+    {
+      $eventCommentImage->delete();
+    }
+  }
+
   public function toggleEventMember($memberId)
   {
     $this->getCommunityEvent()->toggleEventMember($memberId);

--- a/lib/model/doctrine/PluginCommunityTopic.class.php
+++ b/lib/model/doctrine/PluginCommunityTopic.class.php
@@ -47,6 +47,19 @@ abstract class PluginCommunityTopic extends BaseCommunityTopic
     }
   }
 
+  public function preDelete($event)
+  {
+    foreach ($this->Images as $topicImage)
+    {
+      $topicImage->delete();
+    }
+
+    foreach ($this->CommunityTopicComment as $topicComment)
+    {
+      $topicComment->delete();
+    }
+  }
+
   // for pager
   public function getImageFilename()
   {

--- a/lib/model/doctrine/PluginCommunityTopicComment.class.php
+++ b/lib/model/doctrine/PluginCommunityTopicComment.class.php
@@ -31,4 +31,12 @@ abstract class PluginCommunityTopicComment extends BaseCommunityTopicComment
       $this->setNumber(Doctrine::getTable('CommunityTopicComment')->getMaxNumber($this->getCommunityTopicId()) + 1);
     }
   }
+
+  public function preDelete($event)
+  {
+    foreach ($this->Images as $topicCommentImage)
+    {
+      $topicCommentImage->delete();
+    }
+  }
 }

--- a/test/fixtures/999_test_data.yml
+++ b/test/fixtures/999_test_data.yml
@@ -255,6 +255,7 @@ CommunityTopic:
 
 CommunityTopicComment:
   community_topic_comment_a_2:
+    id: 1
     body: "こんにちは"
     CommunityTopic: community_topic_a_2
     Member: member_5
@@ -291,6 +292,15 @@ CommunityTopicComment:
     body: "<&\"'>CommunityTopicComment.body ESCAPING HTML TEST DATA"
     CommunityTopic: community_topic_html_1
     Member: member_html_1
+
+CommunityTopicCommentImage:
+  community_topic_comment_a_2_image:
+    CommunityTopicComment: community_topic_comment_a_2
+    number: 1
+    File:
+      name: dummy_community_topic_comment_a_2_image
+      type: text/plain
+      FileBin: { bin: hogehoge }
 
 CommunityEvent:
   community_event_a_2:

--- a/test/fixtures/999_test_data.yml
+++ b/test/fixtures/999_test_data.yml
@@ -207,6 +207,7 @@ CommunityMemberPosition:
 
 CommunityTopic:
   community_topic_a_2:
+    id: 1
     name: "_aトピ主"
     body: "こんにちは"
     Community: community_a
@@ -252,6 +253,15 @@ CommunityTopic:
     body: "<&\"'>CommunityTopic.body ESCAPING HTML TEST DATA"
     Community: community_a
     Member: member_html_1
+
+CommunityTopicImage:
+  community_topic_a_2_image:
+    CommunityTopic: community_topic_a_2
+    number: 1
+    File:
+      name: dummy_community_topic_a_2_image
+      type: text/plain
+      FileBin: { bin: hogehoge }
 
 CommunityTopicComment:
   community_topic_comment_a_2:

--- a/test/fixtures/999_test_data.yml
+++ b/test/fixtures/999_test_data.yml
@@ -314,6 +314,7 @@ CommunityTopicCommentImage:
 
 CommunityEvent:
   community_event_a_2:
+    id: 1
     Community: community_a
     Member: member_2
     name: '_aイベ主'
@@ -340,6 +341,14 @@ CommunityEvent:
     open_date: '2009-06-11'
     open_date_comment: "<&\"'>CommunityEvent.open_date_comment ESCAPING HTML TEST DATA"
     area: "<&\"'>CommunityEvent.area ESCAPING HTML TEST DATA"
+CommunityEventImage:
+  community_event_a_2_image:
+    CommunityEvent: community_event_a_2
+    number: 1
+    File:
+      name: dummy_community_event_a_2_image
+      type: text/plain
+      FileBin: { bin: hogehoge }
 
 CommunityEventComment:
   community_event_comment_a_2:

--- a/test/fixtures/999_test_data.yml
+++ b/test/fixtures/999_test_data.yml
@@ -333,6 +333,7 @@ CommunityEvent:
 
 CommunityEventComment:
   community_event_comment_a_2:
+    id: 1
     CommunityEvent: community_event_a_2
     Member: member_5
     body: 'こんにちは'
@@ -345,6 +346,15 @@ CommunityEventComment:
     CommunityEvent: community_event_html_1
     Member: member_html_1
     body: "<&\"'>CommunityEventComment.body ESCAPING HTML TEST DATA"
+
+CommunityEventCommentImage:
+  community_event_comment_a_2_image:
+    CommunityEventComment: community_event_comment_a_2
+    number: 1
+    File:
+      name: dummy_community_event_comment_a_2_image
+      type: text/plain
+      FileBin: { bin: hogehoge }
 
 CommunityEventMember:
   community_event_member_a_1:

--- a/test/unit/model/CommunityEventCommentTest.php
+++ b/test/unit/model/CommunityEventCommentTest.php
@@ -1,0 +1,26 @@
+<?php
+
+require_once __DIR__.'/../../bootstrap/unit.php';
+require_once __DIR__.'/../../bootstrap/database.php';
+
+$t = new lime_test(4);
+
+$eventCommentTable = Doctrine_Core::getTable('CommunityEventComment');
+$conn = $eventCommentTable->getConnection();
+
+//------------------------------------------------------------
+$t->diag('CommunityEventComment: Cascading Delete');
+$conn->beginTransaction();
+
+$eventComment = $eventCommentTable->find(1);
+$eventCommentImage = $eventComment->Images[0];
+$fileId = $eventCommentImage->file_id;
+
+$eventComment->delete($conn);
+
+$t->ok(!Doctrine_Core::getTable('CommunityEventComment')->find($eventComment->id), 'community_event_comment is deleted.');
+$t->ok(!Doctrine_Core::getTable('CommunityEventCommentImage')->find($eventCommentImage->id), 'community_event_comment_image is deleted.');
+$t->ok(!Doctrine_Core::getTable('File')->find($fileId), 'file is deleted.');
+$t->ok(!Doctrine_Core::getTable('FileBin')->find($fileId), 'file_bin is deleted.');
+
+$conn->rollback();

--- a/test/unit/model/CommunityEventTest.php
+++ b/test/unit/model/CommunityEventTest.php
@@ -1,0 +1,40 @@
+<?php
+
+require_once __DIR__.'/../../bootstrap/unit.php';
+require_once __DIR__.'/../../bootstrap/database.php';
+
+$t = new lime_test(8);
+
+//------------------------------------------------------------
+$t->diag('CommunityEvent: Cascading Delete');
+$conn->beginTransaction();
+
+$event = Doctrine_Core::getTable('CommunityEvent')->find(1);
+$eventImage = $event->Images[0];
+$file1Id = $eventImage->file_id;
+$eventComment = Doctrine_Core::getTable('CommunityEventComment')->find(1);
+$eventCommentImage = $eventComment->Images[0];
+$file2Id = $eventCommentImage->file_id;
+
+/*
+ * community_event
+ *  |- community_event_image
+ *  |   +- file
+ *  |       +- file_bin
+ *  +- community_event_comment
+ *      +- community_event_comment_image
+ *          +- file
+ *              +- file_bin
+ */
+$event->delete($conn);
+
+$t->ok(!Doctrine_Core::getTable('CommunityEvent')->find($event->id), 'community_event is deleted.');
+$t->ok(!Doctrine_Core::getTable('CommunityEventImage')->find($eventImage->id), 'community_event_image is deleted.');
+$t->ok(!Doctrine_Core::getTable('File')->find($file1Id), 'file is deleted.');
+$t->ok(!Doctrine_Core::getTable('FileBin')->find($file1Id), 'file_bin is deleted.');
+$t->ok(!Doctrine_Core::getTable('CommunityEventComment')->find($eventComment->id), 'community_event_comment is deleted.');
+$t->ok(!Doctrine_Core::getTable('CommunityEventCommentImage')->find($eventCommentImage->id), 'community_event_comment_image is deleted.');
+$t->ok(!Doctrine_Core::getTable('File')->find($file2Id), 'file is deleted.');
+$t->ok(!Doctrine_Core::getTable('FileBin')->find($file2Id), 'file_bin is deleted.');
+
+$conn->rollback();

--- a/test/unit/model/CommunityTopicCommentTest.php
+++ b/test/unit/model/CommunityTopicCommentTest.php
@@ -1,0 +1,26 @@
+<?php
+
+require_once __DIR__.'/../../bootstrap/unit.php';
+require_once __DIR__.'/../../bootstrap/database.php';
+
+$t = new lime_test(4);
+
+$topicCommentTable = Doctrine_Core::getTable('CommunityTopicComment');
+$conn = $topicCommentTable->getConnection();
+
+//------------------------------------------------------------
+$t->diag('CommunityTopicComment: Cascading Delete');
+$conn->beginTransaction();
+
+$topicComment = $topicCommentTable->find(1);
+$topicCommentImage = $topicComment->Images[0];
+$fileId = $topicCommentImage->file_id;
+
+$topicComment->delete($conn);
+
+$t->ok(!Doctrine_Core::getTable('CommunityTopicComment')->find($topicComment->id), 'community_topic_comment is deleted.');
+$t->ok(!Doctrine_Core::getTable('CommunityTopicCommentImage')->find($topicCommentImage->id), 'community_topic_comment_image is deleted.');
+$t->ok(!Doctrine_Core::getTable('File')->find($fileId), 'file is deleted.');
+$t->ok(!Doctrine_Core::getTable('FileBin')->find($fileId), 'file_bin is deleted.');
+
+$conn->rollback();


### PR DESCRIPTION
Bug (バグ) #2591: 画像が添付されたコミュニティトピックを削除しても、管理画面のアップロード画像リストに画像が残る
https://redmine.openpne.jp/issues/2591

上記のチケットに対する修正です。
