### PR TITLE
#3833 スマートフォンにて、コメントに画像が添付されているコミュニティイベントを閲覧すると読み込み中のままになってしまう問題の修正

### DIFF
--- a/apps/api/modules/communityEventComment/templates/searchSuccess.php
+++ b/apps/api/modules/communityEventComment/templates/searchSuccess.php
@@ -1,5 +1,5 @@
 <?php
-use_helper('opCommunityEvent');
+use_helper('opCommunityEvent', 'opCommunityTopic');
 
 $data = array();
 
@@ -13,7 +13,7 @@ if (isset($comments[0]['id']))
     if (count($images) > 0)
     {
       foreach($images as $image){
-        $_comment['images'][] = op_api_event_image($image);
+        $_comment['images'][] = op_api_topic_image($image);
       }
     }
     $data[] = $_comment;


### PR DESCRIPTION
チケット
https://redmine.openpne.jp/issues/3833

存在しないメソッドを使用していた箇所を修正しました。
