### PR TITLE
(fixed #4124, BP from #1640) 通知メールの受け取り可否設定を必須項目とするよう変更

### DIFF
--- a/apps/pc_frontend/modules/communityTopic/templates/_configNotificationMail.php
+++ b/apps/pc_frontend/modules/communityTopic/templates/_configNotificationMail.php
@@ -1,6 +1,6 @@
 <?php if (version_compare(OPENPNE_VERSION, '3.6beta1-dev', '>=') && $form): ?>
 <?php op_include_form('configNotificationMailBox', $form, array(
-  'mark_required_field' => false,
+  'mark_required_field' => true,
   'url'                 => url_for('@config_community_topic_notification_mail?id='.$sf_request->getParameter('id')),
   'button'              => __('Save'),
 )); ?>

--- a/lib/form/opConfigCommunityTopicNotificationMailForm.class.php
+++ b/lib/form/opConfigCommunityTopicNotificationMailForm.class.php
@@ -47,7 +47,7 @@ class opConfigCommunityTopicNotificationMailForm extends BaseForm
     )));
     $this->setValidator('to_pc_address', new sfValidatorChoice(array(
       'choices' => array_keys($this->choices),
-      'required' => false,
+      'required' => true,
     )));
 
     $this->setWidget('to_mobile_address', new sfWidgetFormSelectRadio(array(
@@ -57,7 +57,7 @@ class opConfigCommunityTopicNotificationMailForm extends BaseForm
     )));
     $this->setValidator('to_mobile_address', new sfValidatorChoice(array(
       'choices'  => array_keys($this->choices),
-      'required' => false,
+      'required' => true,
     )));
 
     $this->widgetSchema->setNameFormat('topic_notify[%s]');


### PR DESCRIPTION
Bugチケット: https://redmine.openpne.jp/issues/1640
Backportチケット: https://redmine.openpne.jp/issues/4124