### PR TITLE
(fixed #4125, BP from #4123) 通知メールの受け取り可否設定時のエラーメッセージをカタログに追加

### DIFF
--- a/apps/pc_frontend/i18n/messages.ja.xml
+++ b/apps/pc_frontend/i18n/messages.ja.xml
@@ -183,6 +183,10 @@
         <target>設定を保存しました</target>
       </trans-unit>
       <trans-unit id="">
+        <source>Failed to configure.</source>
+        <target>設定変更に失敗しました。</target>
+      </trans-unit>
+      <trans-unit id="">
         <source>[%Community% Topic] (%1% %community%) %2%</source>
         <target>[%Community%トピック] (%1% %community%) %2%</target>
       </trans-unit>


### PR DESCRIPTION
Bugチケット: https://redmine.openpne.jp/issues/4123
Backportチケット: https://redmine.openpne.jp/issues/4125